### PR TITLE
change token verification location of devtool

### DIFF
--- a/public/src/sdk.js
+++ b/public/src/sdk.js
@@ -8,7 +8,7 @@ class Warroom {
     this.mode = this.urlParams.get("mode");
     if (this.mode === "devtool") {
       this.verifyUrl =
-        "https://external-staging.warroom.wisesight.com:8888/token/verify";
+        "https://miniapp.staging-warroom.wisesight.dev/token/verify";
     } else {
       this.verifyUrl = "https://app.warroom.wisesight.com/token/verify";
     }


### PR DESCRIPTION
ที่ devtool ใช้ไม่ได้ เพราะมัน verify token ผ่านตัว miniapp ในที่เก่าซึ่งเกาะเป็นเหาฉลามอยู่กับ staging external ซึ่งปิดแล้ว

 pull request นี้เปลี่ยน url การ verify token ไปหาตัว miniapp staging 